### PR TITLE
Prevent overwriting existing ~/.aws/credentials

### DIFF
--- a/cmd/go-aws-sso/main.go
+++ b/cmd/go-aws-sso/main.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/service/sso"
 	"github.com/aws/aws-sdk-go/service/sso/ssoiface"
 	"github.com/aws/aws-sdk-go/service/ssooidc/ssooidciface"
@@ -11,9 +15,6 @@ import (
 	"github.com/urfave/cli/v2/altsrc"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"os"
-	"strings"
-	"time"
 )
 
 var (
@@ -189,11 +190,11 @@ func start(oidcClient ssooidciface.SSOOIDCAPI, ssoClient ssoiface.SSOAPI, contex
 
 	if context.Bool("persist") {
 		template := ProcessPersistedCredentialsTemplate(roleCredentials, context.String("profile"), context.String("region"))
-		WriteAWSCredentialsFile(template)
+		WriteAWSCredentialsFile(template, context.String("profile"), true)
 		zap.S().Infof("Credentials expire at: %s\n", time.Unix(*roleCredentials.RoleCredentials.Expiration/1000, 0))
 	} else {
 		template := ProcessCredentialProcessTemplate(*accountInfo.AccountId, *roleInfo.RoleName, context.String("profile"), context.String("region"))
-		WriteAWSCredentialsFile(template)
+		WriteAWSCredentialsFile(template, context.String("profile"), false)
 	}
 
 }

--- a/cmd/go-aws-sso/main_test.go
+++ b/cmd/go-aws-sso/main_test.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"flag"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go/service/sso"
 	"github.com/aws/aws-sdk-go/service/sso/ssoiface"
 	"github.com/aws/aws-sdk-go/service/ssooidc"
 	"github.com/aws/aws-sdk-go/service/ssooidc/ssooidciface"
 	. "github.com/theurichde/go-aws-sso/pkg/sso"
 	"github.com/urfave/cli/v2"
-	"os"
-	"testing"
-	"time"
 )
 
 type mockSSOOIDCClient struct {
@@ -147,7 +148,7 @@ func Test_start(t *testing.T) {
 
 	content, _ := os.ReadFile(CredentialsFilePath)
 	got := string(content)
-	want := "[default]\naws_access_key_id = dummy\naws_secret_access_key = dummy\naws_session_token = dummy\noutput = json\nregion = eu-central-1\n"
+	want := "[default]\naws_access_key_id     = dummy\naws_secret_access_key = dummy\naws_session_token     = dummy\noutput                = json\nregion                = eu-central-1\n"
 
 	if got != want {
 		t.Errorf("Got: %v, but wanted: %v", got, want)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/assume.go
+++ b/internal/assume.go
@@ -2,14 +2,15 @@ package internal
 
 import (
 	"encoding/json"
+	"os"
+	"time"
+
 	"github.com/aws/aws-sdk-go/service/sso"
 	"github.com/aws/aws-sdk-go/service/sso/ssoiface"
 	"github.com/aws/aws-sdk-go/service/ssooidc/ssooidciface"
 	. "github.com/theurichde/go-aws-sso/pkg/sso"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
-	"os"
-	"time"
 )
 
 // AssumeDirectly
@@ -25,14 +26,14 @@ func AssumeDirectly(oidcClient ssooidciface.SSOOIDCAPI, ssoClient ssoiface.SSOAP
 
 	if context.Bool("persist") {
 		template := ProcessPersistedCredentialsTemplate(roleCredentials, context.String("profile"), context.String("region"))
-		WriteAWSCredentialsFile(template)
+		WriteAWSCredentialsFile(template, context.String("profile"), true)
 
 		zap.S().Infof("Successful retrieved credentials for account: %s", accountId)
 		zap.S().Infof("Assumed role: %s", roleName)
 		zap.S().Infof("Credentials expire at: %s\n", time.Unix(*roleCredentials.RoleCredentials.Expiration/1000, 0))
 	} else {
 		template := ProcessCredentialProcessTemplate(accountId, roleName, context.String("profile"), context.String("region"))
-		WriteAWSCredentialsFile(template)
+		WriteAWSCredentialsFile(template, context.String("profile"), false)
 
 		creds := CredentialProcessOutput{
 			Version:         1,

--- a/internal/assume_test.go
+++ b/internal/assume_test.go
@@ -2,15 +2,16 @@ package internal
 
 import (
 	"flag"
+	"io/ioutil"
+	"os"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/service/sso"
 	"github.com/aws/aws-sdk-go/service/sso/ssoiface"
 	"github.com/aws/aws-sdk-go/service/ssooidc"
 	"github.com/aws/aws-sdk-go/service/ssooidc/ssooidciface"
 	. "github.com/theurichde/go-aws-sso/pkg/sso"
 	"github.com/urfave/cli/v2"
-	"io/ioutil"
-	"os"
-	"testing"
 )
 
 type mockSSOOIDCClient struct {
@@ -99,7 +100,7 @@ func TestAssumeDirectly(t *testing.T) {
 	content, _ := ioutil.ReadFile(CredentialsFilePath)
 	defer os.RemoveAll(CredentialsFilePath)
 	got := string(content)
-	want := "[default]\naws_access_key_id = dummy_assume_directly\naws_secret_access_key = dummy_assume_directly\naws_session_token = dummy_assume_directly\noutput = json\nregion = eu-central-1\n"
+	want := "[default]\naws_access_key_id     = dummy_assume_directly\naws_secret_access_key = dummy_assume_directly\naws_session_token     = dummy_assume_directly\noutput                = json\nregion                = eu-central-1\n"
 
 	if got != want {
 		t.Errorf("Got: %v, but wanted: %v", got, want)

--- a/internal/refresh.go
+++ b/internal/refresh.go
@@ -2,15 +2,16 @@ package internal
 
 import (
 	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/service/sso"
 	"github.com/aws/aws-sdk-go/service/sso/ssoiface"
 	"github.com/aws/aws-sdk-go/service/ssooidc/ssooidciface"
 	. "github.com/theurichde/go-aws-sso/pkg/sso"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
-	"os"
-	"strings"
-	"time"
 )
 
 type LastUsageInformation struct {
@@ -53,7 +54,7 @@ func RefreshCredentials(oidcClient ssooidciface.SSOOIDCAPI, ssoClient ssoiface.S
 	check(err)
 
 	template := ProcessPersistedCredentialsTemplate(roleCredentials, context.String("profile"), context.String("region"))
-	WriteAWSCredentialsFile(template)
+	WriteAWSCredentialsFile(template, context.String("profile"), true)
 
 	zap.S().Infof("Successful retrieved credentials for account: %s", *accountId)
 	zap.S().Infof("Assumed role: %s", *roleName)


### PR DESCRIPTION
This change ensures that any existing profiles are not lost from ~/.aws/credentials when using the utility as it will no longer be overwritten. When a profile is specified with --profile name only that specified section is overwritten.

See #14 