### PR TITLE
feat: allow config generation without user prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,6 @@ OPTIONS:
   OPTIONS:
      --start-url value, -u value   set / override the SSO login start-url. (Example: https://my-login.awsapps.com/start#/)
      --region value, -r value      set / override the AWS region
-     --profile value, -p value     the profile name you want to set in your ~/.aws/credentials file (default: "default")
-     --persist                     whether or not you want to write your short-living credentials to ~/.aws/credentials (default: false)
-     --force                       removes the temporary access token and forces the retrieval of a new token (default: false)
-     --debug                       enables debug logging (default: false)
-     --role-name value, -n value   The role name you want to assume
-     --account-id value, -a value  The account id where your role lives in
      --help, -h                    show help
   ```
 

--- a/README.md
+++ b/README.md
@@ -140,11 +140,19 @@ OPTIONS:
      go-aws-sso config generate [command options] [arguments...]
   
   DESCRIPTION:
-     Generates a config file. All available properties are interactively prompted.
+     Generates a config file. All available properties are interactively prompted if not set with command options.
      Overrides the existing config file!
   
   OPTIONS:
-     --help, -h  show help (default: false)
+     --start-url value, -u value   set / override the SSO login start-url. (Example: https://my-login.awsapps.com/start#/)
+     --region value, -r value      set / override the AWS region
+     --profile value, -p value     the profile name you want to set in your ~/.aws/credentials file (default: "default")
+     --persist                     whether or not you want to write your short-living credentials to ~/.aws/credentials (default: false)
+     --force                       removes the temporary access token and forces the retrieval of a new token (default: false)
+     --debug                       enables debug logging (default: false)
+     --role-name value, -n value   The role name you want to assume
+     --account-id value, -a value  The account id where your role lives in
+     --help, -h                    show help
   ```
 
 </details>

--- a/cmd/go-aws-sso/main.go
+++ b/cmd/go-aws-sso/main.go
@@ -25,7 +25,7 @@ var (
 
 func main() {
 
-	initialFlags := []cli.Flag{
+	configFlags := []cli.Flag{
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    "start-url",
 			Aliases: []string{"u"},
@@ -36,6 +36,9 @@ func main() {
 			Aliases: []string{"r"},
 			Usage:   "set / override the AWS region",
 		}),
+	}
+
+	initialFlags := []cli.Flag{
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    "profile",
 			Aliases: []string{"p"},
@@ -62,6 +65,8 @@ func main() {
 		},
 	}
 
+	initialFlags = append(configFlags, initialFlags...)
+
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Printf("Version: %s\nCommit: %s\nBuild Time: %s\n", version, commit, date)
 	}
@@ -76,7 +81,7 @@ func main() {
 					Usage:       "Generate a config file",
 					Description: "Generates a config file. All available properties are interactively prompted if not set with command options.\nOverrides the existing config file!",
 					Action:      GenerateConfigAction,
-					Flags:       []cli.Flag{initialFlags[0], initialFlags[1]},
+					Flags:       configFlags,
 				},
 				{
 					Name:        "edit",

--- a/cmd/go-aws-sso/main.go
+++ b/cmd/go-aws-sso/main.go
@@ -76,7 +76,7 @@ func main() {
 					Usage:       "Generate a config file",
 					Description: "Generates a config file. All available properties are interactively prompted if not set with command options.\nOverrides the existing config file!",
 					Action:      GenerateConfigAction,
-					Flags:       initialFlags,
+					Flags:       []cli.Flag{initialFlags[0], initialFlags[1]},
 				},
 				{
 					Name:        "edit",

--- a/cmd/go-aws-sso/main.go
+++ b/cmd/go-aws-sso/main.go
@@ -74,8 +74,9 @@ func main() {
 				{
 					Name:        "generate",
 					Usage:       "Generate a config file",
-					Description: "Generates a config file. All available properties are interactively prompted.\nOverrides the existing config file!",
+					Description: "Generates a config file. All available properties are interactively prompted if not set with command options.\nOverrides the existing config file!",
 					Action:      GenerateConfigAction,
+					Flags:       initialFlags,
 				},
 				{
 					Name:        "edit",

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,13 +1,14 @@
 package internal
 
 import (
+	"os"
+	"path"
+
 	"github.com/lithammer/fuzzysearch/fuzzy"
 	. "github.com/theurichde/go-aws-sso/pkg/sso"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
-	"os"
-	"path"
 )
 
 type AppConfig struct {
@@ -27,11 +28,20 @@ func promptRegion(prompt Prompt) string {
 	return region
 }
 
-func GenerateConfigAction(_ *cli.Context) error {
+func GenerateConfigAction(context *cli.Context) error {
 
 	prompter := Prompter{}
-	startUrl := promptStartUrl(prompter, "")
-	region := promptRegion(prompter)
+	startUrl := context.String("start-url")
+	region := context.String("region")
+
+	if startUrl == "" {
+		startUrl = promptStartUrl(prompter, "")
+	}
+
+	if region == "" {
+		region = promptRegion(prompter)
+	}
+
 	appConfig := AppConfig{
 		StartUrl: startUrl,
 		Region:   region,


### PR DESCRIPTION
This PR will allow a config file to be generated without prompting the user for answers if they provide `--start-url` or `--region` as command options to `config generate`. If either one or both of these are omitted the user is prompted for an answer in the usual way.

It is an attempted implementation for #104 