### PR TITLE
fix: use exe name in credential_process value

### DIFF
--- a/pkg/sso/file_system.go
+++ b/pkg/sso/file_system.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path"
+
 	"github.com/aws/aws-sdk-go/service/sso"
 	"go.uber.org/zap"
 	"gopkg.in/ini.v1"
-	"os"
-	"path"
 )
 
 var CredentialsFilePath = GetCredentialsFilePath()
@@ -34,8 +35,10 @@ func ProcessPersistedCredentialsTemplate(credentials *sso.GetRoleCredentialsOutp
 }
 
 func ProcessCredentialProcessTemplate(accountId string, roleName string, region string) CredentialsFileTemplate {
+	exeName, err := os.Executable()
+	check(err)
 	profileTemplate := CredentialsFileTemplate{
-		CredentialProcess: fmt.Sprintf("go-aws-sso assume -a %s -n %s", accountId, roleName),
+		CredentialProcess: fmt.Sprintf("%s assume -a %s -n %s", exeName, accountId, roleName),
 		Region:            region,
 	}
 	return profileTemplate


### PR DESCRIPTION
This PR replaces the hardcoded `go-aws-sso` executable name with the full path to the executable when writing to the credential_process to the `~/.aws/credentials` file . This will let people use the utility outside of their PATH, or with a renamed executable without experiencing error when trying to run `aws` commands with credential_process set in their profile.

I have tested on Mac, Linux and Windows

See #106 