### PR TITLE
fix label repeat on fuzzy search arrow keypress

### DIFF
--- a/internal/aws.go
+++ b/internal/aws.go
@@ -53,8 +53,9 @@ func RetrieveAccountInfo(clientInformation ClientInformation, ssoClient ssoiface
 		accountsToSelect = append(accountsToSelect, linePrefix+strconv.Itoa(i)+" "+*info.AccountName+" "+*info.AccountId)
 	}
 
-	label := "Select your account - Hint: fuzzy search supported. To choose one account directly just enter #{Int}"
-	indexChoice, _ := selector.Select(label, accountsToSelect, fuzzySearchWithPrefixAnchor(accountsToSelect, linePrefix))
+	fmt.Println("Hint: fuzzy search supported. To choose one account directly just enter #{Int}.")
+
+	indexChoice, _ := selector.Select("Select your account", accountsToSelect, fuzzySearchWithPrefixAnchor(accountsToSelect, linePrefix))
 
 	fmt.Println()
 


### PR DESCRIPTION
There is an issue with the fuzzy search when using the arrow keys to navigate the list (see below). I think this happens when the terminal width is less than the label? I didn't dig into it much.

This PR "fixes" this behaviour, by means of moving some of the prompt to a separate print line just before the select. So the prompt label is shorter, which makes the issue less likely to occur.

Before:

https://github.com/theurichde/go-aws-sso/assets/3265173/4bb173b9-5398-4312-844c-ff8fbfa4c4bc

After:

https://github.com/theurichde/go-aws-sso/assets/3265173/2a2e44ba-a01c-4185-b885-3fe919ee2ed8

Thanks for a great tool!
