### PR TITLE
fix: quiet flag to stop credential process errors

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -35,5 +35,9 @@ jobs:
           go vet github.com/theurichde/go-aws-sso/internal
       - name: Tests
         run: |
+          go clean -r -testcache
+          go clean -r -x -modcache
+          go clean -r -x -testcache
+          go clean -r -x -cache
           go test -v ./...
           go test -v github.com/theurichde/go-aws-sso/internal

--- a/README.md
+++ b/README.md
@@ -67,15 +67,16 @@ DESCRIPTION:
    Assume directly into an account and SSO role
 
 OPTIONS:
-   --start-url value, -u value   set / override the SSO login start-url. (Example: https://my-login.awsapps.com/start#/)
-   --region value, -r value      set / override the AWS region
-   --profile value, -p value     the profile name you want to set in your ~/.aws/credentials file (default: "default")
-   --persist                     whether or not you want to write your short-living credentials to ~/.aws/credentials (default: false)
-   --force                       removes the temporary access token and forces the retrieval of a new token (default: false)
-   --debug                       enables debug logging (default: false)
-   --role-name value, -n value   The role name you want to assume
-   --account-id value, -a value  The account id where your role lives in
-   --help, -h                    show help
+   --start-url value, -u value     set / override the SSO login start-url. (Example: https://my-login.awsapps.com/start#/)
+   --region value, -r value        set / override the AWS region
+   --profile value, -p value       the profile name you want to set in your ~/.aws/credentials file (default: "default")
+   --persist                       whether or not you want to write your short-living credentials to ~/.aws/credentials (default: false)
+   --force                         removes the temporary access token and forces the retrieval of a new token (default: false)
+   --debug                         enables debug logging (default: false)
+   --role-name value, -n value     The role name you want to assume
+   --account-id value, -a value    The account id where your role lives in
+   --quiet, -q, --non-interactive  disables logger output (default: false)
+   --help, -h                      show help
 ```
 
 * Execute `go-aws-sso assume --account-id YOUR_ID --role-name YOUR_ROLE_NAME`

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ OPTIONS:
    --debug                         enables debug logging (default: false)
    --role-name value, -n value     The role name you want to assume
    --account-id value, -a value    The account id where your role lives in
-   --quiet, -q          disables logger output (default: false)
+   --quiet, -q                     disables logger output (default: false)
    --help, -h                      show help
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ OPTIONS:
    --debug                         enables debug logging (default: false)
    --role-name value, -n value     The role name you want to assume
    --account-id value, -a value    The account id where your role lives in
-   --quiet, -q, --non-interactive  disables logger output (default: false)
+   --quiet, -q          disables logger output (default: false)
    --help, -h                      show help
 ```
 

--- a/cmd/go-aws-sso/main.go
+++ b/cmd/go-aws-sso/main.go
@@ -130,6 +130,14 @@ func main() {
 					Aliases: []string{"a"},
 					Usage:   "The account id where your role lives in",
 				}),
+				&cli.BoolFlag{
+					Name:     "quiet",
+					Usage:    "disables logger output",
+					Aliases:  []string{"q", "non-interactive"},
+					Value:    false,
+					Hidden:   false,
+					Required: false,
+				},
 			}...),
 		},
 	}
@@ -256,6 +264,10 @@ func applyForceFlag(context *cli.Context) {
 }
 
 func initializeLogger(context *cli.Context) {
+	if context.Bool("quiet") {
+		zap.ReplaceGlobals(zap.NewNop())
+		return
+	}
 	config := zap.NewProductionEncoderConfig()
 	config.EncodeTime = zapcore.TimeEncoderOfLayout("2006-01-02 15:04:05")
 

--- a/cmd/go-aws-sso/main.go
+++ b/cmd/go-aws-sso/main.go
@@ -133,7 +133,7 @@ func main() {
 				&cli.BoolFlag{
 					Name:     "quiet",
 					Usage:    "disables logger output",
-					Aliases:  []string{"q", "non-interactive"},
+					Aliases:  []string{"q"},
 					Value:    false,
 					Hidden:   false,
 					Required: false,

--- a/internal/assume_test.go
+++ b/internal/assume_test.go
@@ -44,10 +44,14 @@ func (m mockSSOClient) GetRoleCredentials(*sso.GetRoleCredentialsInput) (*sso.Ge
 }
 
 func TestAssumeDirectly(t *testing.T) {
-
+	os.Remove(os.TempDir() + "/go-aws-sso.lock")
 	temp, err := os.CreateTemp("", "go-aws-sso-assume-directly_")
 	check(err)
 	CredentialsFilePath = temp.Name()
+	defer func(path string) {
+		os.RemoveAll(path)
+		os.Remove(os.TempDir() + "/go-aws-sso.lock")
+	}(CredentialsFilePath)
 
 	dummyInt := int64(132465)
 	dummy := "dummy_assume_directly"
@@ -97,7 +101,6 @@ func TestAssumeDirectly(t *testing.T) {
 	AssumeDirectly(oidcClient, ssoClient, ctx)
 
 	content, _ := os.ReadFile(CredentialsFilePath)
-	defer os.RemoveAll(CredentialsFilePath)
 	got := string(content)
 	want := "[default]\naws_access_key_id     = dummy_assume_directly\naws_secret_access_key = dummy_assume_directly\naws_session_token     = dummy_assume_directly\nregion                = eu-central-1\n"
 

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -52,7 +51,7 @@ func TestWriteConfig(t *testing.T) {
 			configFile, err := os.Open(tempFile)
 			fail(err, t)
 
-			bytes, err := ioutil.ReadFile(configFile.Name())
+			bytes, err := os.ReadFile(configFile.Name())
 			fail(err, t)
 
 			gotAppConfig := AppConfig{}

--- a/pkg/sso/file_system.go
+++ b/pkg/sso/file_system.go
@@ -38,7 +38,7 @@ func ProcessCredentialProcessTemplate(accountId string, roleName string, region 
 	exeName, err := os.Executable()
 	check(err)
 	profileTemplate := CredentialsFileTemplate{
-		CredentialProcess: fmt.Sprintf("%s assume -a %s -n %s", exeName, accountId, roleName),
+		CredentialProcess: fmt.Sprintf("%s assume -q -a %s -n %s", exeName, accountId, roleName),
 		Region:            region,
 	}
 	return profileTemplate

--- a/pkg/sso/file_system_test.go
+++ b/pkg/sso/file_system_test.go
@@ -3,7 +3,6 @@ package sso
 import (
 	"encoding/json"
 	"gopkg.in/ini.v1"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -75,7 +74,7 @@ func TestWriteClientInfoToFile(t *testing.T) {
 			}
 
 			got := ClientInformation{}
-			content, _ := ioutil.ReadFile(tt.args.dest)
+			content, _ := os.ReadFile(tt.args.dest)
 			err = json.Unmarshal(content, &got)
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION
[Resolves #159](https://github.com/theurichde/go-aws-sso/issues/159)

- `main.initializeLogger()` now installs a no-op logger as the global logger if a "quiet" flag has been passed to the CLI argument parser
  - Added coverage for initializeLogger to establish its behavior with different flags or defaults 
- Added `-q`, `--quiet`, and `--non-interactive` flags as options on the `assume` subcommand. These could be moved to a higher scope later if useful, but they currently only appear to be relevant to this subcommand 
- Modified the credential process template to add the `-q` flag on profile creation
- Updated README with current help output
- Changed references to `ioutil.ReadFile` to `os.ReadFile` to resolve deprecation notes
- Partially resolved a unit test race condition which was making GitHub Actions builds fail intermittently
  - Purged build caches, since any successful runs would prevent subsequent failures
  - Added pre- and post- removal of the lock-file to allow test runs to complete without stopping due to the lock
  - Ensured the defer functions were established before test operations which could crash the process

Discussion: the root problem here is the frequent use of `zap.Fatal()` through the application code. This causes the test execution process to immediately terminate without collecting failure logging when any application error occurs. Since the zap logger is not initialized for test runs, it is difficult to see where the problem is happening without debugging. Debugging is hard since it worked 100% of the time on my machine, only failing in the GitLab Actions. I wasn't able to determine if the failure was due to the `main` and `assume` tests having an interaction because of concurrency, or due to interactions between subsequent runs in the Actions environment with restored caches. I suspect the former, but it got late. I was thinking that the same behavior, but with better failure notification in the tests might be achieved by using `zap.Panic()` rather than `zap.Fatal()`, but I haven't thought through the implications. Providing a wrapper interface/factory for zap that could be overridden with a mock in the tests would also solve the same problems. The temp file location might also have a testing override to ensure that test cases are isolated from each other.

Not fixed: 
- The executable name provided in the credential process template can include spaces from the file system path. This can cause failures if the go-aws-sso executable is not in a "normal" location. I'm not 100% certain that just quoting the fully qualified executable path in that file works cross-platform. Go does not have a batteries-included version of the Python  `shlex.quote` function and I didn't want to add a dependency for a different issue than the one I was working on.