### PR TITLE
fix: ensure profile is added to credential_process to prevent default overwrite

### DIFF
--- a/cmd/go-aws-sso/main.go
+++ b/cmd/go-aws-sso/main.go
@@ -220,7 +220,7 @@ func start(oidcClient ssooidciface.SSOOIDCAPI, ssoClient ssoiface.SSOAPI, contex
 		WriteAWSCredentialsFile(&template, context.String("profile"))
 		zap.S().Infof("Credentials expire at: %s\n", time.Unix(*roleCredentials.RoleCredentials.Expiration/1000, 0))
 	} else {
-		template := ProcessCredentialProcessTemplate(*accountInfo.AccountId, *roleInfo.RoleName, context.String("region"))
+		template := ProcessCredentialProcessTemplate(*accountInfo.AccountId, *roleInfo.RoleName, context.String("region"), context.String("profile"))
 		WriteAWSCredentialsFile(&template, context.String("profile"))
 	}
 

--- a/internal/assume.go
+++ b/internal/assume.go
@@ -32,7 +32,7 @@ func AssumeDirectly(oidcClient ssooidciface.SSOOIDCAPI, ssoClient ssoiface.SSOAP
 		zap.S().Infof("Assumed role: %s", roleName)
 		zap.S().Infof("Credentials expire at: %s\n", time.Unix(*roleCredentials.RoleCredentials.Expiration/1000, 0))
 	} else {
-		template := ProcessCredentialProcessTemplate(accountId, roleName, context.String("region"))
+		template := ProcessCredentialProcessTemplate(accountId, roleName, context.String("region"), context.String("profile"))
 		WriteAWSCredentialsFile(&template, context.String("profile"))
 
 		creds := CredentialProcessOutput{

--- a/pkg/sso/file_system.go
+++ b/pkg/sso/file_system.go
@@ -34,15 +34,15 @@ func ProcessPersistedCredentialsTemplate(credentials *sso.GetRoleCredentialsOutp
 	return profileTemplate
 }
 
-func ProcessCredentialProcessTemplate(accountId string, roleName string, region string) CredentialsFileTemplate {
+func ProcessCredentialProcessTemplate(accountId string, roleName string, region string, profile string) CredentialsFileTemplate {
 	exeName, err := os.Executable()
 	check(err)
-	return processCredentialProcessTemplateWithExeName(exeName, accountId, roleName, region)
+	return processCredentialProcessTemplateWithExeName(exeName, accountId, roleName, region, profile)
 }
 
-func processCredentialProcessTemplateWithExeName(exeName string, accountId string, roleName string, region string) CredentialsFileTemplate {
+func processCredentialProcessTemplateWithExeName(exeName string, accountId string, roleName string, region string, profile string) CredentialsFileTemplate {
 	profileTemplate := CredentialsFileTemplate{
-		CredentialProcess: fmt.Sprintf("%s assume -q -a %s -n %s", exeName, accountId, roleName),
+		CredentialProcess: fmt.Sprintf("%s assume -q -a %s -n %s -p %s", exeName, accountId, roleName, profile),
 		Region:            region,
 	}
 	return profileTemplate

--- a/pkg/sso/file_system_test.go
+++ b/pkg/sso/file_system_test.go
@@ -146,6 +146,7 @@ func TestProcessCredentialProcessTemplateWithExeName(t *testing.T) {
 		accountId    string
 		roleName     string
 		region       string
+		profile      string
 		fileTemplate CredentialsFileTemplate
 	}{
 		{
@@ -154,8 +155,9 @@ func TestProcessCredentialProcessTemplateWithExeName(t *testing.T) {
 			accountId: "accountid",
 			roleName:  "rolename",
 			region:    "region",
+			profile:   "default",
 			fileTemplate: CredentialsFileTemplate{
-				CredentialProcess: fmt.Sprintf("@exe#name$ assume -q -a accountid -n rolename"),
+				CredentialProcess: fmt.Sprintf("@exe#name$ assume -q -a accountid -n rolename -p default"),
 				Region:            "region",
 			},
 		},
@@ -165,8 +167,9 @@ func TestProcessCredentialProcessTemplateWithExeName(t *testing.T) {
 			accountId: "accountid",
 			roleName:  "rolename",
 			region:    "region",
+			profile:   "default",
 			fileTemplate: CredentialsFileTemplate{
-				CredentialProcess: fmt.Sprintf("e x e name assume -q -a accountid -n rolename"),
+				CredentialProcess: fmt.Sprintf("e x e name assume -q -a accountid -n rolename -p default"),
 				Region:            "region",
 			},
 		},
@@ -179,6 +182,7 @@ func TestProcessCredentialProcessTemplateWithExeName(t *testing.T) {
 				tc.accountId,
 				tc.roleName,
 				tc.region,
+				tc.profile,
 			)
 			if fileTemplate != tc.fileTemplate {
 				t.Errorf("File template is not equal. Got: %+v, want: %+v", fileTemplate, tc.fileTemplate)


### PR DESCRIPTION
This PR ensures that the profile is added to the credential_process command to prevent the default profile values getting overwritten every time a command using a profile is run

Fixes #201 