### PR TITLE
fix: limit SSO account page size

### DIFF
--- a/internal/aws.go
+++ b/internal/aws.go
@@ -34,7 +34,7 @@ func RetrieveRoleInfo(accountInfo *sso.AccountInfo, clientInformation ClientInfo
 }
 
 func RetrieveAccountInfo(clientInformation ClientInformation, ssoClient ssoiface.SSOAPI, selector Prompt) (*sso.AccountInfo, awserr.RequestFailure) {
-	var maxSize int64 = 1000 // default is 20, but sometimes you have more accounts available ;-)
+	var maxSize int64 = 100
 	lai := sso.ListAccountsInput{AccessToken: &clientInformation.AccessToken, MaxResults: &maxSize}
 	accounts, err := ssoClient.ListAccounts(&lai)
 	if err != nil {

--- a/internal/aws_test.go
+++ b/internal/aws_test.go
@@ -1,0 +1,70 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/sso"
+	"github.com/aws/aws-sdk-go/service/sso/ssoiface"
+	. "github.com/theurichde/go-aws-sso/pkg/sso"
+)
+
+type accountListingSSOClient struct {
+	ssoiface.SSOAPI
+	t        *testing.T
+	requests []sso.ListAccountsInput
+}
+
+func (m *accountListingSSOClient) ListAccounts(input *sso.ListAccountsInput) (*sso.ListAccountsOutput, error) {
+	m.t.Helper()
+	m.requests = append(m.requests, *input)
+	if input.MaxResults == nil {
+		m.t.Fatal("ListAccounts MaxResults must be set")
+	}
+	if *input.MaxResults > 100 {
+		m.t.Fatalf("ListAccounts MaxResults = %d, want no more than 100", *input.MaxResults)
+	}
+
+	accountID := "123456789012"
+	accountName := "Production"
+	return &sso.ListAccountsOutput{
+		AccountList: []*sso.AccountInfo{
+			{
+				AccountId:   &accountID,
+				AccountName: &accountName,
+			},
+		},
+	}, nil
+}
+
+type accountSelectionPrompt struct{}
+
+func (p accountSelectionPrompt) Select(_ string, toSelect []string, _ func(input string, index int) bool) (int, string) {
+	return 0, toSelect[0]
+}
+
+func (p accountSelectionPrompt) Prompt(_ string, _ string) string {
+	return ""
+}
+
+func TestRetrieveAccountInfoUsesAWSAllowedMaxResults(t *testing.T) {
+	ssoClient := &accountListingSSOClient{t: t}
+
+	accountInfo, awsErr := RetrieveAccountInfo(
+		ClientInformation{AccessToken: "access-token"},
+		ssoClient,
+		accountSelectionPrompt{},
+	)
+
+	if awsErr != nil {
+		t.Fatalf("RetrieveAccountInfo returned AWS error: %v", awsErr)
+	}
+	if accountInfo == nil {
+		t.Fatal("RetrieveAccountInfo returned nil account info")
+	}
+	if got := *accountInfo.AccountId; got != "123456789012" {
+		t.Fatalf("account ID = %s, want 123456789012", got)
+	}
+	if got := *ssoClient.requests[0].MaxResults; got != 100 {
+		t.Fatalf("ListAccounts MaxResults = %d, want 100", got)
+	}
+}


### PR DESCRIPTION
Fixes #203.

## Summary
- limit ListAccounts MaxResults to AWS's allowed maximum of 100
- add a regression test covering the account retrieval page size

## Tests
- go test ./...