### PR TITLE
fix: update aws list account max size to docs limit

### DIFF
--- a/internal/aws.go
+++ b/internal/aws.go
@@ -34,7 +34,7 @@ func RetrieveRoleInfo(accountInfo *sso.AccountInfo, clientInformation ClientInfo
 }
 
 func RetrieveAccountInfo(clientInformation ClientInformation, ssoClient ssoiface.SSOAPI, selector Prompt) (*sso.AccountInfo, awserr.RequestFailure) {
-	var maxSize int64 = 1000 // default is 20, but sometimes you have more accounts available ;-)
+	var maxSize int64 = 100 // default is 20, but sometimes you have more accounts available ;-)
 	lai := sso.ListAccountsInput{AccessToken: &clientInformation.AccessToken, MaxResults: &maxSize}
 	accounts, err := ssoClient.ListAccounts(&lai)
 	if err != nil {


### PR DESCRIPTION
The max_result in the documentation is 100.
https://docs.aws.amazon.com/singlesignon/latest/PortalAPIReference/API_ListAccounts.html