### PR TITLE
chore: fix small typo

### DIFF
--- a/pkg/sso/aws.go
+++ b/pkg/sso/aws.go
@@ -202,7 +202,7 @@ func openUrlInBrowser(url string) {
 	case "wsl":
 		err = exec.Command("wslview", url).Start()
 	default:
-		err = fmt.Errorf("could not open %s - unsupported platform. Please open the URL manually or use the BROWSER environemnt variable to point to your browser", url)
+		err = fmt.Errorf("could not open %s - unsupported platform. Please open the URL manually or use the BROWSER environment variable to point to your browser", url)
 	}
 	if err != nil {
 		zap.S().Error(err)


### PR DESCRIPTION
Stumbled over this while reading through the source around #203 — `environemnt` -> `environment` in the unsupported-platform error message of `openUrlInBrowser`.